### PR TITLE
Clean out indirection

### DIFF
--- a/lib/plek.rb
+++ b/lib/plek.rb
@@ -6,8 +6,6 @@ class Plek
 
   SERVICES = {
     "production.www"                 => "www.gov.uk",
-    "production.needs"               => "needotron.production.alphagov.co.uk",
-    "production.data"                => "imminence.production.alphagov.co.uk",
     "production.assets"              => "static.production.alphagov.co.uk",
     "production.cdn"                 => "d17tffe05zdvwj.cloudfront.net",
     "production.publication-preview" => "private-frontend.production.alphagov.co.uk",
@@ -16,8 +14,6 @@ class Plek
     "production.#{DEFAULT_PATTERN}"  => "%s.production.alphagov.co.uk",
 
     "preview.www"                    => "www.preview.alphagov.co.uk",
-    "preview.needs"                  => "needotron.preview.alphagov.co.uk",
-    "preview.data"                   => "imminence.preview.alphagov.co.uk",
     "preview.assets"                 => "static.preview.alphagov.co.uk",
     "preview.cdn"                    => "djb1962t8apu5.cloudfront.net",
     "preview.publication-preview"    => "private-frontend.preview.alphagov.co.uk",
@@ -27,16 +23,12 @@ class Plek
     "preview.#{DEFAULT_PATTERN}"     => "%s.preview.alphagov.co.uk",
 
     "staging.frontend"               => "demo.alphagov.co.uk",
-    "staging.needs"                  => "needotron.alpha.gov.uk",
     "staging.publisher"              => "guides.staging.alphagov.co.uk",
-    "staging.data"                   => "imminence.staging.alphagov.co.uk",
     "staging.assets"                 => "static.staging.alphagov.co.uk",
     "staging.assets"                 => "static.staging.alphagov.co.uk",
     "staging.publication-preview"    => "private-frontend.staging.alphagov.co.uk",
     "staging.#{DEFAULT_PATTERN}"     => "%s.staging.alphagov.co.uk",
 
-    "development.needs"              => "needotron.dev.gov.uk",
-    "development.data"               => "imminence.dev.gov.uk",
     "development.assets"             => "static.dev.gov.uk",
     "development.cdn"                => "static.dev.gov.uk",
     "development.whitehall"          => "whitehall.dev.gov.uk",
@@ -44,8 +36,6 @@ class Plek
     "development.publication-preview"=> "www.dev.gov.uk",
     "development.#{DEFAULT_PATTERN}" => "%s.dev.gov.uk",
 
-    "test.needs"                     => "needotron.test.gov.uk",
-    "test.data"                      => "imminence.test.gov.uk",
     "test.publication-preview"       => "www.test.gov.uk",
     "test.cdn"                       => "static.test.gov.uk",
     "test.whitehall"                 => "whitehall.test.alphagov.co.uk",


### PR DESCRIPTION
Plek's always been a stop-gap measure to fill a gap before we have proper internal DNS and service discovery. As such it had a lot of code designed to mask app names behind service names.

I'm trying to thin it out a bit to make it a little easier to understand as we work out how to replace it and as I need to make a few changes. Removing the masking helps a bit with that.
