### PR TITLE
use GOVUK_APP_DOMAIN to find domain

### DIFF
--- a/lib/plek.rb
+++ b/lib/plek.rb
@@ -3,33 +3,36 @@ require 'plek/version'
 
 class Plek
   DEFAULT_PATTERN = "pattern".freeze
+  DEFAULT_DOMAIN = ENV['GOVUK_APP_DOMAIN'] || 'dev.gov.uk'
 
   SERVICES = {
     "production.www"                 => "www.gov.uk",
     "production.assets"              => "static.production.alphagov.co.uk",
     "production.cdn"                 => "d17tffe05zdvwj.cloudfront.net",
     "production.publication-preview" => "private-frontend.production.alphagov.co.uk",
-    "production.#{DEFAULT_PATTERN}"  => "%s.production.alphagov.co.uk",
+    "production.#{DEFAULT_PATTERN}"  => "%s.#{DEFAULT_DOMAIN}",
 
     "preview.www"                    => "www.preview.alphagov.co.uk",
     "preview.assets"                 => "static.preview.alphagov.co.uk",
     "preview.cdn"                    => "djb1962t8apu5.cloudfront.net",
     "preview.publication-preview"    => "private-frontend.preview.alphagov.co.uk",
-    "preview.#{DEFAULT_PATTERN}"     => "%s.preview.alphagov.co.uk",
+    "preview.#{DEFAULT_PATTERN}"     => "%s.#{DEFAULT_DOMAIN}",
 
     "staging.frontend"               => "demo.alphagov.co.uk",
     "staging.publisher"              => "guides.staging.alphagov.co.uk",
     "staging.assets"                 => "static.staging.alphagov.co.uk",
     "staging.publication-preview"    => "private-frontend.staging.alphagov.co.uk",
-    "staging.#{DEFAULT_PATTERN}"     => "%s.staging.alphagov.co.uk",
+    "staging.#{DEFAULT_PATTERN}"     => "%s.#{DEFAULT_DOMAIN}",
 
     "development.assets"             => "static.dev.gov.uk",
     "development.cdn"                => "static.dev.gov.uk",
     "development.publication-preview"=> "www.dev.gov.uk",
-    "development.#{DEFAULT_PATTERN}" => "%s.dev.gov.uk",
+    "development.#{DEFAULT_PATTERN}" => "%s.#{DEFAULT_DOMAIN}",
 
     "test.publication-preview"       => "www.test.gov.uk",
     "test.cdn"                       => "static.test.gov.uk",
+    # FIXME: in the test environment, we should set GOVUK_APP_DOMAIN
+    # directly rather than govuk_platform
     "test.#{DEFAULT_PATTERN}"        => "%s.test.gov.uk",
   }.freeze
 

--- a/test/plek_test.rb
+++ b/test/plek_test.rb
@@ -10,16 +10,6 @@ class PlekTest < Test::Unit::TestCase
     assert_equal "whitehall.test.gov.uk", URI.parse(whitehall_url).host
   end
 
-  def test_should_return_whitehall_preview_host_domain
-    whitehall_url = Plek.new("preview").find("whitehall")
-    assert_equal "whitehall.preview.alphagov.co.uk", URI.parse(whitehall_url).host
-  end
-
-  def test_should_return_whitehall_production_host_domain
-    whitehall_url = Plek.new("production").find("whitehall")
-    assert_equal "whitehall.production.alphagov.co.uk", URI.parse(whitehall_url).host
-  end
-
   def test_should_return_non_whitehall_preview_host_url_as_ssl
     url = Plek.new("preview").find("non-whitehall-service")
     assert_equal "https", URI.parse(url).scheme
@@ -35,39 +25,8 @@ class PlekTest < Test::Unit::TestCase
     assert_equal "http", URI.parse(url).scheme
   end
 
-  def test_should_return_tariff_preview_host_domain
-    tariff_url = Plek.new("preview").find("tariff")
-    assert_equal "https://tariff.preview.alphagov.co.uk", tariff_url
-  end
-
   def test_should_return_subdomain_divided_source_in_dev
     url = Plek.new("development").find("explore.reviewomatic")
     assert_equal "http://explore.reviewomatic.dev.gov.uk", url
   end
-
-  def test_should_return_subdomain_divided_source_in_preview
-    url = Plek.new("preview").find("explore.reviewomatic")
-    assert_equal "https://explore.reviewomatic.preview.alphagov.co.uk", url
-  end
-
-  def test_should_return_subdomain_divided_source_in_production
-    url = Plek.new("production").find("explore.reviewomatic")
-    assert_equal "https://explore.reviewomatic.production.alphagov.co.uk", url
-  end
-
-  def test_should_return_dash_divided_source_in_dev
-    url = Plek.new("development").find("explore-reviewomatic")
-    assert_equal "http://explore-reviewomatic.dev.gov.uk", url
-  end
-
-  def test_should_return_dash_divided_source_in_preview
-    url = Plek.new("preview").find("explore-reviewomatic")
-    assert_equal "https://explore-reviewomatic.preview.alphagov.co.uk", url
-  end
-
-  def test_should_return_dash_divided_source_in_production
-    url = Plek.new("production").find("explore-reviewomatic")
-    assert_equal "https://explore-reviewomatic.production.alphagov.co.uk", url
-  end
-
 end


### PR DESCRIPTION
Don't merge for the moment, until alphagov/puppet@f0b727d3c has been deployed to all environments.

Use GOVUK_APP_DOMAIN to determine the app domain, rather than creating it ourselves.

This is a first step towards reducing the implicit knowledge contained in Plek and moving it to puppet-driven configuration.
