### PR TITLE
Allow setting a default parent domain

### DIFF
--- a/lib/plek.rb
+++ b/lib/plek.rb
@@ -9,7 +9,7 @@ class Plek
   attr_accessor :parent_domain
 
   def initialize(domain_to_use = nil)
-    self.parent_domain = domain_to_use || ENV['GOVUK_APP_DOMAIN'] || raise(NoConfigurationError, 'Expected GOVUK_APP_DOMAIN to be set. Perhaps you should run your task through govuk_setenv <appname>?')
+    self.parent_domain = domain_to_use || self.class.default_parent_domain || ENV['GOVUK_APP_DOMAIN'] || raise(NoConfigurationError, 'Expected GOVUK_APP_DOMAIN to be set. Perhaps you should run your task through govuk_setenv <appname>?')
   end
 
   # Find the URI for a service/application.
@@ -38,5 +38,10 @@ class Plek
     # as well as the new style:
     #     Plek.new.find('foo')
     alias_method :current, :new
+
+    # Allow setting a class-level default domain to use when none is given
+    # This is intended to be used in test setups to insulate the tests from the environment
+    @default_parent_domain = nil
+    attr_accessor :default_parent_domain
   end
 end

--- a/test/plek_test.rb
+++ b/test/plek_test.rb
@@ -75,4 +75,26 @@ class PlekTest < Test::Unit::TestCase
     ENV['GOVUK_APP_DOMAIN'] = 'foo.bar.baz'
     assert_equal Plek.new.find("foo"), Plek.current.find("foo")
   end
+
+  def test_should_allow_setting_default_parent_domain
+    Plek.default_parent_domain = 'foo.gov.uk'
+    assert_equal 'https://static.foo.gov.uk', Plek.new.find('static')
+  ensure
+    Plek.default_parent_domain = nil
+  end
+
+  def test_default_parent_domain_should_override_env
+    Plek.default_parent_domain = 'foo.gov.uk'
+    ENV['GOVUK_APP_DOMAIN'] = 'bar.gov.uk'
+    assert_equal 'https://static.foo.gov.uk', Plek.new.find('static')
+  ensure
+    Plek.default_parent_domain = nil
+  end
+
+  def test_default_parent_domain_should_not_override_given_domain
+    Plek.default_parent_domain = 'foo.gov.uk'
+    assert_equal 'https://static.bar.gov.uk', Plek.new('bar.gov.uk').find('static')
+  ensure
+    Plek.default_parent_domain = nil
+  end
 end


### PR DESCRIPTION
Ability to set a default parent domain at class level.  This will allow
application test setup to specify a default domain, and thereby decouple
the tests from the environment.

For example you could add the following to `test_helper.rb`:

``` ruby
require 'plek'
Plek.default_parent_domain = 'dev.gov.uk'
```

Note: due to the way Slimmer is currently implemented, this needs to be before the app is loaded (before `config/environment.rb` is required).  I have an idea for how to modify Slimmer to delay the Plek lookup until it's needed and thereby avoid this problem.
