### PR TITLE
Return a sensible default GOVUK_APP_DOMAIN value

### DIFF
--- a/lib/plek.rb
+++ b/lib/plek.rb
@@ -9,7 +9,7 @@ class Plek
   attr_accessor :parent_domain
 
   def initialize(domain_to_use = nil)
-    self.parent_domain = ENV['GOVUK_APP_DOMAIN'] || default_parent_domain
+    self.parent_domain = domain_to_use || ENV['GOVUK_APP_DOMAIN'] || default_parent_domain
   end
 
   # Find the URI for a service/application.


### PR DESCRIPTION
_This is a sketch for discussion_

The way Plek works, and is used, means that it tries to find
`ENV['GOVUK_APP_DOMAIN']` immediately, which will causes any Rails apps
that include Plek in an initialiser to die when instantiating themselves.

This makes simple tasks like `rake db:migrate` or `rails generate`
somewhat more painful to run.

This fixes the problem by only failing if the perceived RAILS/RACK_ENV is
production, otherwise it returns a sensible default.
