### PR TITLE
Add asset_root to find out the URL that assets are stored on

### DIFF
--- a/lib/plek.rb
+++ b/lib/plek.rb
@@ -24,6 +24,10 @@ class Plek
     end
   end
 
+  def asset_root
+    env_var_or_dev_fallback("GOVUK_ASSET_ROOT") { find("static") }
+  end
+
   def website_root
     env_var_or_dev_fallback("GOVUK_WEBSITE_ROOT") { find("www") }
   end

--- a/test/asset_root_test.rb
+++ b/test/asset_root_test.rb
@@ -1,0 +1,36 @@
+require_relative "test_helper"
+
+describe Plek do
+  before do
+    ENV.delete("GOVUK_ASSET_ROOT")
+    ENV.delete("RAILS_ENV")
+    ENV.delete("RACK_ENV")
+  end
+
+  describe "retreiving the asset_host" do
+    it "should return the GOVUK_ASSET_ROOT env variable" do
+      ENV["GOVUK_ASSET_ROOT"] = "http://static.dev.gov.uk"
+      assert_equal "http://static.dev.gov.uk", Plek.new("foo.gov.uk").asset_root
+    end
+
+    describe "When GOVUK_ASSET_ROOT env variable isn't set" do
+      it "should raise an exception if RAILS_ENV is production" do
+        ENV["RAILS_ENV"] = "production"
+        assert_raises Plek::NoConfigurationError do
+          Plek.new("foo.gov.uk").asset_root
+        end
+      end
+
+      it "should raise an exception if RACK_ENV is production" do
+        ENV["RACK_ENV"] = "production"
+        assert_raises Plek::NoConfigurationError do
+          Plek.new("foo.gov.uk").asset_root
+        end
+      end
+
+      it "should return find('static') otherwise" do
+        assert_equal "https://static.foo.gov.uk", Plek.new("foo.gov.uk").asset_root
+      end
+    end
+  end
+end


### PR DESCRIPTION
As an application, we may want to find the asset URL for the environment we're in. This is essentially the same as website_root only it uses a different ENV var that we currently ship to all nodes.
