### PR TITLE
Remove unnecessary dependency on Builder gem

### DIFF
--- a/lib/plek.rb
+++ b/lib/plek.rb
@@ -1,4 +1,3 @@
-require 'builder'
 require 'plek/version'
 
 class Plek

--- a/plek.gemspec
+++ b/plek.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |s|
 
   s.files        = Dir.glob("lib/**/*") + %w(README.md)
   s.require_path = 'lib'
-  s.add_runtime_dependency 'builder'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'gem_publisher', '~> 1.1.1'
 end


### PR DESCRIPTION
Builder was used back in the days when Plek could return XML. That's long since gone, so we don't need builder any more.

And with that, plek has no runtime dependencies!
