### PR TITLE
Use DEV_DOMAIN `ENV` variable instead of dev.gov.uk

### DIFF
--- a/lib/plek.rb
+++ b/lib/plek.rb
@@ -3,12 +3,13 @@ require 'plek/version'
 class Plek
   class NoConfigurationError < StandardError; end
   DEFAULT_PATTERN = "pattern".freeze
-  HTTP_DOMAINS = ['dev.gov.uk']
+  DEV_DOMAIN = ENV['DEV_DOMAIN'] || 'dev.gov.uk'
+  HTTP_DOMAINS = [ DEV_DOMAIN ]
 
   attr_accessor :parent_domain
 
   def initialize(domain_to_use = nil)
-    self.parent_domain = domain_to_use || env_var_or_dev_fallback("GOVUK_APP_DOMAIN", "dev.gov.uk")
+    self.parent_domain = domain_to_use || env_var_or_dev_fallback("GOVUK_APP_DOMAIN", DEV_DOMAIN)
   end
 
   # Find the URI for a service/application.


### PR DESCRIPTION
We're doing some initial investigations into using the gov.uk bits and pieces for our publishing platform, and we hit a bit of a snag when running locally, as Plek defaults to using https for any domain other than dev.gov.uk. We've got round this by setting an ENV variable, which if isn't present, defaults back to dev.gov.uk. Thought people might find it useful :smile: 
