### PR TITLE
Add option to find to allow forcing plain http

### DIFF
--- a/lib/plek.rb
+++ b/lib/plek.rb
@@ -13,11 +13,11 @@ class Plek
   end
 
   # Find the URI for a service/application.
-  def find(service)
+  def find(service, options = {})
     name = name_for(service)
     host = "#{name}.#{parent_domain}"
 
-    if HTTP_DOMAINS.include?(parent_domain)
+    if options[:force_http] or HTTP_DOMAINS.include?(parent_domain)
       "http://#{host}"
     else
       "https://#{host}"

--- a/test/plek_test.rb
+++ b/test/plek_test.rb
@@ -32,6 +32,11 @@ class PlekTest < MiniTest::Unit::TestCase
     assert_equal "http", URI.parse(url).scheme
   end
 
+  def test_should_return_http_when_requested
+    url = Plek.new("production.alphagov.co.uk").find("non-whitehall-service", :force_http => true)
+    assert_equal "http", URI.parse(url).scheme
+  end
+
   def test_should_return_tariff_preview_host_domain
     tariff_url = Plek.new("preview.alphagov.co.uk").find("tariff")
     assert_equal "https://tariff.preview.alphagov.co.uk", tariff_url


### PR DESCRIPTION
The router will be talking to the backends over plain http, so we need to option to get the plain http base URL.
