### PR TITLE
Allow custom URIs for services to be defined

### DIFF
--- a/lib/plek.rb
+++ b/lib/plek.rb
@@ -67,7 +67,7 @@ class Plek
   end
 
   def defined_service_uri_for(service)
-    service_name = service.upcase.sub(/\-/,'_')
+    service_name = service.upcase.gsub(/-/,'_')
     var_name = "PLEK_SERVICE_#{service_name}_URI"
 
     if (uri = ENV[var_name] and ! uri.empty?)

--- a/test/service_uri_test.rb
+++ b/test/service_uri_test.rb
@@ -5,6 +5,7 @@ describe Plek do
     before do
       ENV.delete("PLEK_SERVICE_FOO_URI")
       ENV.delete("PLEK_SERVICE_BAR_URI")
+      ENV.delete("PLEK_SERVICE_FOO_BAR_API_URI")
       ENV.delete("GOVUK_APP_DOMAIN")
     end
 
@@ -16,6 +17,11 @@ describe Plek do
     it "upcases and underscores the service name in the environment variable" do
       ENV["PLEK_SERVICE_FOO_API_URI"] = "http://foo.localhost:5001"
       assert_equal "http://foo.localhost:5001", Plek.new().find("foo-api")
+    end
+
+    it "upcases and underscores all hyphens in the service name in the environment variable" do
+      ENV["PLEK_SERVICE_FOO_BAR_API_URI"] = "http://foo.localhost:5001"
+      assert_equal "http://foo.localhost:5001", Plek.new().find("foo-bar-api")
     end
 
     it "falls back to regular behaviour when env variable is nil or empty" do


### PR DESCRIPTION
_Note: this pull request is an idea that I've had to make running apps easier when you don't have our dev VM. It's definitely up for discussion if you can think of a better way to do it._

Allow custom URIs for services to be defined using environment variables, so that it is easier to set up and run multiple services in isolation without them having to be running at particular hostnames.

A service URI can be defined using the following environment variable naming convention:

```
# replace <service> with the name of the service, uppercased
# and underscored
export PLEK_SERVICE_<service>_URI=http://localhost:3000
```

Existing behaviour of the gem is not affected when these environment variables are not present.
