### PR TITLE
Add Plek#website_uri and Plek#asset_uri methods

### DIFF
--- a/lib/plek.rb
+++ b/lib/plek.rb
@@ -1,4 +1,5 @@
 require 'plek/version'
+require 'uri'
 
 class Plek
   class NoConfigurationError < StandardError; end
@@ -36,6 +37,14 @@ class Plek
 
   def website_root
     env_var_or_dev_fallback("GOVUK_WEBSITE_ROOT") { find("www") }
+  end
+
+  def asset_uri
+    URI(asset_root)
+  end
+
+  def website_uri
+    URI(website_root)
   end
 
   def name_for(service)

--- a/test/uri_test.rb
+++ b/test/uri_test.rb
@@ -1,0 +1,13 @@
+require_relative "test_helper"
+
+describe Plek do
+  it "should return a URI object for the webite root" do
+    ENV["GOVUK_WEBSITE_ROOT"] = "https://www.test.gov.uk"
+    assert_equal URI.parse("https://www.test.gov.uk"), Plek.new.website_uri
+  end
+
+  it "should return a URI object for the asset root" do
+    ENV["GOVUK_ASSET_ROOT"] = "https://assets.test.gov.uk"
+    assert_equal URI.parse("https://assets.test.gov.uk"), Plek.new.asset_uri
+  end
+end


### PR DESCRIPTION
This makes it easier to access the website hostname (`Plek.new.website_uri.host`) and also to build urls (`Plek.new.website_uri + 'some/path'`) without having to worry about things like trailing slashes, etc.
