### PR TITLE
Remove unused DEFAULT_PATTERN constant.

### DIFF
--- a/lib/plek.rb
+++ b/lib/plek.rb
@@ -3,7 +3,6 @@ require 'uri'
 
 class Plek
   class NoConfigurationError < StandardError; end
-  DEFAULT_PATTERN = "pattern".freeze
   DEV_DOMAIN = ENV['DEV_DOMAIN'] || 'dev.gov.uk'
   HTTP_DOMAINS = [ DEV_DOMAIN ]
 


### PR DESCRIPTION
This hasn't been used since https://github.com/alphagov/plek/pull/6 was merged over a year ago.
