### PR TITLE
Add `Plek.find` to simplify client interface.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Plek
 "Plek" is Afrikaans. It means "Location." Plek is used to generate the correct hostnames for internal GOV.UK services, eg:
 
 ```ruby
-Plek.current.find('frontend')
+Plek.find('frontend')
 ```
 
 returns `https://frontend.production.alphagov.co.uk`. This means we can use this in our code and let our environment configuration figure out the correct hosts for us at runtime.
@@ -21,7 +21,7 @@ PLEK_SERVICE_EXAMPLE_CHEESE_THING_URI=http://example.com bundle exec rails s
 would set
 
 ```ruby
-Plek.current.find('example-cheese-thing')
+Plek.find('example-cheese-thing')
 ```
 
 to `http://example.com`. Underscores in environment variables are converted to dashes in Plek names as demonstrated.

--- a/lib/plek.rb
+++ b/lib/plek.rb
@@ -60,6 +60,10 @@ class Plek
     # as well as the new style:
     #     Plek.new.find('foo')
     alias_method :current, :new
+
+    def find(*args)
+      new.find(*args)
+    end
   end
 
   private

--- a/test/plek_test.rb
+++ b/test/plek_test.rb
@@ -77,6 +77,11 @@ class PlekTest < MiniTest::Unit::TestCase
     assert_equal Plek.new.find("foo"), Plek.current.find("foo")
   end
 
+  def test_should_be_able_to_avoid_instantiation_in_the_client
+    ENV['GOVUK_APP_DOMAIN'] = 'foo.bar.baz'
+    assert_equal Plek.new.find("foo"), Plek.find("foo")
+  end
+
   def test_scheme_relative_urls
     url = Plek.new("dev.gov.uk").find("service", scheme_relative: true)
     assert_equal "//service.dev.gov.uk", url


### PR DESCRIPTION
The clients almost never keep instances of Plek around so there's not much reason to require them to instantiate transient objects.
