### PR TITLE
Add a method that returns URI objects

### DIFF
--- a/lib/plek.rb
+++ b/lib/plek.rb
@@ -12,7 +12,7 @@ class Plek
     self.parent_domain = domain_to_use || env_var_or_dev_fallback("GOVUK_APP_DOMAIN", DEV_DOMAIN)
   end
 
-  # Find the URI for a service/application.
+  # Find the URI for a service/application. Return the URI as a string.
   def find(service, options = {})
     name = name_for(service)
     if service_uri = defined_service_uri_for(name)
@@ -28,6 +28,11 @@ class Plek
     else
       "https://#{host}"
     end
+  end
+
+  # Find the URI for a service/application. Return a URI object.
+  def find_uri(*args)
+    URI(find(*args))
   end
 
   def asset_root
@@ -63,6 +68,10 @@ class Plek
 
     def find(*args)
       new.find(*args)
+    end
+
+    def find_uri(*args)
+      new.find_uri(*args)
     end
   end
 

--- a/test/plek_test.rb
+++ b/test/plek_test.rb
@@ -82,6 +82,11 @@ class PlekTest < MiniTest::Unit::TestCase
     assert_equal Plek.new.find("foo"), Plek.find("foo")
   end
 
+  def test_should_be_able_to_avoid_instantiation_with_uris
+    ENV['GOVUK_APP_DOMAIN'] = 'foo.bar.baz'
+    assert_equal Plek.new.find_uri("foo"), Plek.find_uri("foo")
+  end
+
   def test_scheme_relative_urls
     url = Plek.new("dev.gov.uk").find("service", scheme_relative: true)
     assert_equal "//service.dev.gov.uk", url

--- a/test/uri_test.rb
+++ b/test/uri_test.rb
@@ -1,6 +1,10 @@
 require_relative "test_helper"
 
 describe Plek do
+  before do
+    ENV.delete("PLEK_SERVICE_CHEESE_URI")
+  end
+
   it "should return a URI object for the webite root" do
     ENV["GOVUK_WEBSITE_ROOT"] = "https://www.test.gov.uk"
     assert_equal URI.parse("https://www.test.gov.uk"), Plek.new.website_uri
@@ -9,5 +13,27 @@ describe Plek do
   it "should return a URI object for the asset root" do
     ENV["GOVUK_ASSET_ROOT"] = "https://assets.test.gov.uk"
     assert_equal URI.parse("https://assets.test.gov.uk"), Plek.new.asset_uri
+  end
+
+  it "should return a URI object for a service" do
+    service_uri = Plek.new("test.gov.uk").find_uri("cheese")
+    assert_equal "cheese.test.gov.uk", service_uri.host
+  end
+
+  it "should return an HTTPS URI by default" do
+    service_uri = Plek.new("test.gov.uk").find_uri("cheese")
+    assert_equal "https", service_uri.scheme
+  end
+
+  it "should return an HTTP URI when told" do
+    service_uri = Plek.new("test.gov.uk").find_uri("cheese", force_http: true)
+    assert_equal "http", service_uri.scheme
+  end
+
+  it "should raise an error when given an invalid URI" do
+    ENV["PLEK_SERVICE_CHEESE_URI"] = "http://mouldy|cheese.test.gov.uk"
+    assert_raises URI::InvalidURIError do
+      Plek.new.find_uri("cheese")
+    end
   end
 end


### PR DESCRIPTION
Using `URI` objects instead of strings means we can build paths without
having to concatenate strings together and worrying about, for instance,
whether the URI ends with a slash or not. For example:

```
Plek.find_uri("stuff") + "things"  # URL:http://stuff.dev.gov.uk/things
```

rather than:

```
Plek.find("stuff") + "things"  # "http://stuff.dev.gov.ukthings"
```

The method name is for consistency with the `asset_uri` and
`website_uri` methods, so that any method ending `_uri` will return a
`URI` object, rather than a string.
