### PR TITLE
Release version 1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+# 1.10.0
+
+  * Add `Plek.find_uri` for accessing `URI` objects for any service
+
 # 1.9.0
 
   * Add `Plek.find` to simplify client interface.

--- a/lib/plek/version.rb
+++ b/lib/plek/version.rb
@@ -1,3 +1,3 @@
 class Plek
-  VERSION = '1.9.0'
+  VERSION = '1.10.0'
 end


### PR DESCRIPTION
This releases #23, giving us the `find_uri` method.