### PR TITLE
Allow an ENV variable to be prepended to the host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+# DEV
+
+  * Add `PLEK_HOSTNAME_PREFIX` environment variable, which prepends the contents
+    to the returned hostname
+
 # 1.10.0
 
   * Add `Plek.find_uri` for accessing `URI` objects for any service

--- a/go/plek.go
+++ b/go/plek.go
@@ -40,6 +40,9 @@ var httpDomains = map[string]bool{
 // domain as a string. The app domain is taken from the GOVUK_APP_DOMAIN
 // environment variable. If this is unset, "dev.gov.uk" is used.
 //
+// If PLEK_HOSTNAME_PREFIX is present in the environment, it will be prepended
+// to the hostname.
+//
 // The URLs for an individual service can be overridden by setting a corresponding
 // PLEK_SERVICE_FOO_URI environment variable. For example, to override the "foo-api"
 // service url, set PLEK_SERVICE_FOO_API_URI to the base URL of the service.
@@ -72,6 +75,12 @@ func New(parentDomain string) Plek {
 // FindURL returns the base URL for the given service name as a *url.URL
 func (p Plek) FindURL(serviceName string) *url.URL {
 	u := &url.URL{Scheme: "https", Host: serviceName + "." + p.parentDomain}
+
+	hostnamePrefix := os.Getenv("PLEK_HOSTNAME_PREFIX")
+	if hostnamePrefix != "" {
+		u.Host = hostnamePrefix + u.Host
+	}
+
 	if httpDomains[p.parentDomain] {
 		u.Scheme = "http"
 	}

--- a/go/plek_test.go
+++ b/go/plek_test.go
@@ -99,6 +99,15 @@ var packageFindExamples = []FindExample{
 		ServiceName:    "foo",
 		ExpectedURL:    "http://foo.dev.gov.uk",
 	},
+	// Setting a hostname prefix
+	{
+		GovukAppDomain: "",
+		ServiceName:    "foo",
+		ExpectedURL:    "http://draft-foo.dev.gov.uk",
+		Environ: map[string]string{
+			"PLEK_HOSTNAME_PREFIX": "draft-",
+		},
+	},
 	// Overriding a specific service URL with an ENV var.
 	{
 		GovukAppDomain: "foo.com",
@@ -123,6 +132,16 @@ var packageFindExamples = []FindExample{
 		ServiceName:    "foo",
 		ExpectedURL:    "http://invalid%hostname.com",
 		Environ:        map[string]string{"PLEK_SERVICE_FOO_URI": "http://invalid%hostname.com"},
+	},
+	// PLEK_SERVICE_FOO_BAR_URI overrides the hostname prefix
+	{
+		GovukAppDomain: "foo.com",
+		ServiceName:    "foo-bar",
+		ExpectedURL:    "http://anything.example.com",
+		Environ: map[string]string{
+			"PLEK_SERVICE_FOO_BAR_URI": "http://anything.example.com",
+			"PLEK_HOSTNAME_PREFIX":     "draft-",
+		},
 	},
 }
 

--- a/lib/plek.rb
+++ b/lib/plek.rb
@@ -40,6 +40,9 @@ class Plek
   # matches the {DEV_DOMAIN}, the returned URL will be a http URL, otherwise it
   # will be https.
   #
+  # If PLEK_HOSTNAME_PREFIX is present in the environment, it will be prepended
+  # to the hostname.
+  #
   # The URL for a given service can be overridden by setting a corresponding
   # environment variable.  eg if +PLEK_SERVICE_EXAMPLE_CHEESE_THING_URI+ was
   # set, +Plek.new.find('example-cheese-thing')+ would return the value of that
@@ -59,6 +62,10 @@ class Plek
     end
 
     host = "#{name}.#{parent_domain}"
+
+    if host_prefix = ENV['PLEK_HOSTNAME_PREFIX']
+      host = "#{host_prefix}#{host}"
+    end
 
     if options[:scheme_relative]
       "//#{host}"

--- a/test/plek_test.rb
+++ b/test/plek_test.rb
@@ -87,6 +87,13 @@ class PlekTest < MiniTest::Unit::TestCase
     assert_equal Plek.new.find_uri("foo"), Plek.find_uri("foo")
   end
 
+  def test_should_prepend_data_from_the_environment
+    ENV['PLEK_HOSTNAME_PREFIX'] = 'test-'
+    assert_equal "https://test-foo.preview.alphagov.co.uk", Plek.new("preview.alphagov.co.uk").find("foo")
+  ensure
+    ENV.delete("PLEK_HOSTNAME_PREFIX")
+  end
+
   def test_scheme_relative_urls
     url = Plek.new("dev.gov.uk").find("service", scheme_relative: true)
     assert_equal "//service.dev.gov.uk", url


### PR DESCRIPTION
When `PLEK_HOSTNAME_PREFIX` is set, it will be prepended to the returned host.

This behaviour is overridden by the `PLEK_SERVICE_xxx_URI` functionality, because prepending plus manual override would cause unexpected behaviour.

We intend to use this in the draft stack to append `draft-` to our hostnames.

## TODO

- [x] @mattbostock to push Go code