### PR TITLE
Fix another test cleanup.

### DIFF
--- a/test/website_root_test.rb
+++ b/test/website_root_test.rb
@@ -2,7 +2,7 @@ require_relative "test_helper"
 
 describe Plek do
   describe "retreiving the website_root" do
-    before do
+    after do
       ENV.delete("GOVUK_WEBSITE_ROOT")
       ENV.delete("RAILS_ENV")
       ENV.delete("RACK_ENV")


### PR DESCRIPTION
Because this was cleaning up in a before, not an after it could
potentially leak environment settings into other tests.