### PR TITLE
Add a test to document that force_http ignored

### DIFF
--- a/test/service_uri_test.rb
+++ b/test/service_uri_test.rb
@@ -34,5 +34,9 @@ describe Plek do
       assert_equal "http://baz.dev.gov.uk", Plek.new().find("baz") # not defined
     end
 
+    it "ignores the force_http parameter" do
+      ENV["PLEK_SERVICE_FOO_URI"] = "https://foo.localhost:5001"
+      assert_equal "https://foo.localhost:5001", Plek.new().find("foo", :force_http => true)
+    end
   end
 end


### PR DESCRIPTION
Add a test to document that if `PLEK_SERVICE_FOO_URI` is set, then the
`force_http` parameter is ignored.

* * *

It feels like this is a bug as `force_http` implies to me that the URI scheme will be set to `http` no matter what. Either way, I think it's helpful to document in the tests. I couldn't see an equivalent in the Go library.