### PR TITLE
Run tests under multiple rubies

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,8 +1,11 @@
 #!/bin/bash -x
 set -e
-rm -f Gemfile.lock
-bundle install --path "${HOME}/bundles/${JOB_NAME}"
-bundle exec rake
+
+for version in 1.9.3-p484 2.1 2.2; do
+  rm -f Gemfile.lock
+  RBENV_VERSION=$version bundle install --path "${HOME}/bundles/${JOB_NAME}"
+  RBENV_VERSION=$version bundle exec rake
+done
 
 cd go
 go test -v

--- a/plek.gemspec
+++ b/plek.gemspec
@@ -18,4 +18,5 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'gem_publisher', '~> 1.1.1'
+  s.add_development_dependency 'minitest'
 end

--- a/plek.gemspec
+++ b/plek.gemspec
@@ -19,4 +19,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake'
   s.add_development_dependency 'gem_publisher', '~> 1.1.1'
   s.add_development_dependency 'minitest'
+  s.add_development_dependency 'climate_control'
 end

--- a/test/asset_root_test.rb
+++ b/test/asset_root_test.rb
@@ -2,29 +2,26 @@ require_relative "test_helper"
 
 describe Plek do
   describe "retreiving the asset_host" do
-    before do
-      ENV.delete("GOVUK_ASSET_ROOT")
-      ENV.delete("RAILS_ENV")
-      ENV.delete("RACK_ENV")
-    end
-
     it "should return the GOVUK_ASSET_ROOT env variable" do
-      ENV["GOVUK_ASSET_ROOT"] = "http://static.dev.gov.uk"
-      assert_equal "http://static.dev.gov.uk", Plek.new("foo.gov.uk").asset_root
+      ClimateControl.modify GOVUK_ASSET_ROOT: "http://static.dev.gov.uk" do
+        assert_equal "http://static.dev.gov.uk", Plek.new("foo.gov.uk").asset_root
+      end
     end
 
     describe "When GOVUK_ASSET_ROOT env variable isn't set" do
       it "should raise an exception if RAILS_ENV is production" do
-        ENV["RAILS_ENV"] = "production"
-        assert_raises Plek::NoConfigurationError do
-          Plek.new("foo.gov.uk").asset_root
+        ClimateControl.modify RAILS_ENV: "production" do
+          assert_raises Plek::NoConfigurationError do
+            Plek.new("foo.gov.uk").asset_root
+          end
         end
       end
 
       it "should raise an exception if RACK_ENV is production" do
-        ENV["RACK_ENV"] = "production"
-        assert_raises Plek::NoConfigurationError do
-          Plek.new("foo.gov.uk").asset_root
+        ClimateControl.modify RACK_ENV: "production" do
+          assert_raises Plek::NoConfigurationError do
+            Plek.new("foo.gov.uk").asset_root
+          end
         end
       end
 

--- a/test/plek_test.rb
+++ b/test/plek_test.rb
@@ -1,6 +1,6 @@
 require_relative "test_helper"
 
-class PlekTest < MiniTest::Unit::TestCase
+class PlekTest < Minitest::Test
   def test_should_return_whitehall_test_host_domain
     whitehall_url = Plek.new("test.gov.uk").find("whitehall")
     assert_equal "whitehall.test.gov.uk", URI.parse(whitehall_url).host

--- a/test/plek_test.rb
+++ b/test/plek_test.rb
@@ -27,11 +27,10 @@ class PlekTest < Minitest::Test
   end
 
   def test_should_magically_return_http_for_dev_gov_uk
-    ENV['GOVUK_APP_DOMAIN'] = 'dev.gov.uk'
-    url = Plek.new.find("non-whitehall-service")
-    assert_equal "http", URI.parse(url).scheme
-  ensure
-    ENV.delete("GOVUK_APP_DOMAIN")
+    ClimateControl.modify GOVUK_APP_DOMAIN: 'dev.gov.uk' do
+      url = Plek.new.find("non-whitehall-service")
+      assert_equal "http", URI.parse(url).scheme
+    end
   end
 
   def test_should_return_http_when_requested
@@ -75,31 +74,27 @@ class PlekTest < Minitest::Test
   end
 
   def test_should_be_able_to_use_current_for_old_style_calls
-    ENV['GOVUK_APP_DOMAIN'] = 'foo.bar.baz'
-    assert_equal Plek.new.find("foo"), Plek.current.find("foo")
-  ensure
-    ENV.delete("GOVUK_APP_DOMAIN")
+    ClimateControl.modify GOVUK_APP_DOMAIN: 'foo.bar.baz' do
+      assert_equal Plek.new.find("foo"), Plek.current.find("foo")
+    end
   end
 
   def test_should_be_able_to_avoid_instantiation_in_the_client
-    ENV['GOVUK_APP_DOMAIN'] = 'foo.bar.baz'
-    assert_equal Plek.new.find("foo"), Plek.find("foo")
-  ensure
-    ENV.delete("GOVUK_APP_DOMAIN")
+    ClimateControl.modify GOVUK_APP_DOMAIN: 'foo.bar.baz' do
+      assert_equal Plek.new.find("foo"), Plek.find("foo")
+    end
   end
 
   def test_should_be_able_to_avoid_instantiation_with_uris
-    ENV['GOVUK_APP_DOMAIN'] = 'foo.bar.baz'
-    assert_equal Plek.new.find_uri("foo"), Plek.find_uri("foo")
-  ensure
-    ENV.delete("GOVUK_APP_DOMAIN")
+    ClimateControl.modify GOVUK_APP_DOMAIN: 'foo.bar.baz' do
+      assert_equal Plek.new.find_uri("foo"), Plek.find_uri("foo")
+    end
   end
 
   def test_should_prepend_data_from_the_environment
-    ENV['PLEK_HOSTNAME_PREFIX'] = 'test-'
-    assert_equal "https://test-foo.preview.alphagov.co.uk", Plek.new("preview.alphagov.co.uk").find("foo")
-  ensure
-    ENV.delete("PLEK_HOSTNAME_PREFIX")
+    ClimateControl.modify PLEK_HOSTNAME_PREFIX: 'test-' do
+      assert_equal "https://test-foo.preview.alphagov.co.uk", Plek.new("preview.alphagov.co.uk").find("foo")
+    end
   end
 
   def test_scheme_relative_urls

--- a/test/service_uri_test.rb
+++ b/test/service_uri_test.rb
@@ -2,36 +2,36 @@ require_relative "test_helper"
 
 describe Plek do
   describe "overriding the uri for a service" do
-    after do
-      ENV.delete("PLEK_SERVICE_FOO_URI")
-      ENV.delete("PLEK_SERVICE_BAR_URI")
-      ENV.delete("PLEK_SERVICE_FOO_BAR_API_URI")
-      ENV.delete("GOVUK_APP_DOMAIN")
-    end
-
     it "looks for an env variable matching the service name and returns its value when present" do
-      ENV["PLEK_SERVICE_FOO_URI"] = "http://foo.localhost:5001"
-      assert_equal "http://foo.localhost:5001", Plek.new().find("foo")
+      ClimateControl.modify PLEK_SERVICE_FOO_URI: "http://foo.localhost:5001" do
+        assert_equal "http://foo.localhost:5001", Plek.new().find("foo")
+      end
     end
 
     it "upcases and underscores the service name in the environment variable" do
-      ENV["PLEK_SERVICE_FOO_API_URI"] = "http://foo.localhost:5001"
-      assert_equal "http://foo.localhost:5001", Plek.new().find("foo-api")
+      ClimateControl.modify PLEK_SERVICE_FOO_API_URI: "http://foo.localhost:5001" do
+        assert_equal "http://foo.localhost:5001", Plek.new().find("foo-api")
+      end
     end
 
     it "upcases and underscores all hyphens in the service name in the environment variable" do
-      ENV["PLEK_SERVICE_FOO_BAR_API_URI"] = "http://foo.localhost:5001"
-      assert_equal "http://foo.localhost:5001", Plek.new().find("foo-bar-api")
+      ClimateControl.modify PLEK_SERVICE_FOO_BAR_API_URI: "http://foo.localhost:5001" do
+        assert_equal "http://foo.localhost:5001", Plek.new().find("foo-bar-api")
+      end
     end
 
     it "falls back to regular behaviour when env variable is nil or empty" do
-      ENV["GOVUK_APP_DOMAIN"] = "dev.gov.uk"
-      ENV["PLEK_SERVICE_FOO_URI"] = nil
-      ENV["PLEK_SERVICE_BAR_URI"] = ""
+      new_env = {
+        GOVUK_APP_DOMAIN: "dev.gov.uk",
+        PLEK_SERVICE_FOO_URI: nil,
+        PLEK_SERVICE_BAR_URI: "",
+      }
 
-      assert_equal "http://foo.dev.gov.uk", Plek.new().find("foo")
-      assert_equal "http://bar.dev.gov.uk", Plek.new().find("bar")
-      assert_equal "http://baz.dev.gov.uk", Plek.new().find("baz") # not defined
+      ClimateControl.modify new_env do
+        assert_equal "http://foo.dev.gov.uk", Plek.new().find("foo")
+        assert_equal "http://bar.dev.gov.uk", Plek.new().find("bar")
+        assert_equal "http://baz.dev.gov.uk", Plek.new().find("baz") # not defined
+      end
     end
 
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,5 @@
 require "minitest/autorun"
+require "climate_control"
 
 $LOAD_PATH.unshift("../lib")
 require "plek"

--- a/test/uri_test.rb
+++ b/test/uri_test.rb
@@ -1,20 +1,16 @@
 require_relative "test_helper"
 
 describe Plek do
-  after do
-    ENV.delete("PLEK_SERVICE_CHEESE_URI")
-    ENV.delete("GOVUK_WEBSITE_ROOT")
-    ENV.delete("GOVUK_ASSET_ROOT")
-  end
-
   it "should return a URI object for the webite root" do
-    ENV["GOVUK_WEBSITE_ROOT"] = "https://www.test.gov.uk"
-    assert_equal URI.parse("https://www.test.gov.uk"), Plek.new.website_uri
+    ClimateControl.modify GOVUK_WEBSITE_ROOT: "https://www.test.gov.uk" do
+      assert_equal URI.parse("https://www.test.gov.uk"), Plek.new.website_uri
+    end
   end
 
   it "should return a URI object for the asset root" do
-    ENV["GOVUK_ASSET_ROOT"] = "https://assets.test.gov.uk"
-    assert_equal URI.parse("https://assets.test.gov.uk"), Plek.new.asset_uri
+    ClimateControl.modify GOVUK_ASSET_ROOT: "https://assets.test.gov.uk" do
+      assert_equal URI.parse("https://assets.test.gov.uk"), Plek.new.asset_uri
+    end
   end
 
   it "should return a URI object for a service" do
@@ -33,9 +29,10 @@ describe Plek do
   end
 
   it "should raise an error when given an invalid URI" do
-    ENV["PLEK_SERVICE_CHEESE_URI"] = "http://mouldy|cheese.test.gov.uk"
-    assert_raises URI::InvalidURIError do
-      Plek.new.find_uri("cheese")
+    ClimateControl.modify PLEK_SERVICE_CHEESE_URI: "http://mouldy|cheese.test.gov.uk" do
+      assert_raises URI::InvalidURIError do
+        Plek.new.find_uri("cheese")
+      end
     end
   end
 end

--- a/test/website_root_test.rb
+++ b/test/website_root_test.rb
@@ -2,29 +2,26 @@ require_relative "test_helper"
 
 describe Plek do
   describe "retreiving the website_root" do
-    after do
-      ENV.delete("GOVUK_WEBSITE_ROOT")
-      ENV.delete("RAILS_ENV")
-      ENV.delete("RACK_ENV")
-    end
-
     it "should return the GOVUK_WEBSITE_ROOT env variable" do
-      ENV["GOVUK_WEBSITE_ROOT"] = "https://www.test.gov.uk"
-      assert_equal "https://www.test.gov.uk", Plek.new("foo.gov.uk").website_root
+      ClimateControl.modify GOVUK_WEBSITE_ROOT: "https://www.test.gov.uk" do
+        assert_equal "https://www.test.gov.uk", Plek.new("foo.gov.uk").website_root
+      end
     end
 
     describe "When GOVUK_WEBSITE_ROOT env variable isn't set" do
       it "should raise an exception if RAILS_ENV is production" do
-        ENV["RAILS_ENV"] = "production"
-        assert_raises Plek::NoConfigurationError do
-          Plek.new("foo.gov.uk").website_root
+        ClimateControl.modify RAILS_ENV: "production" do
+          assert_raises Plek::NoConfigurationError do
+            Plek.new("foo.gov.uk").website_root
+          end
         end
       end
 
       it "should raise an exception if RACK_ENV is production" do
-        ENV["RACK_ENV"] = "production"
-        assert_raises Plek::NoConfigurationError do
-          Plek.new("foo.gov.uk").website_root
+        ClimateControl.modify RACK_ENV: "production" do
+          assert_raises Plek::NoConfigurationError do
+            Plek.new("foo.gov.uk").website_root
+          end
         end
       end
 


### PR DESCRIPTION
We should test this library against the versions of Ruby we use in production. Testing against Ruby 2.2 requires the minitest gem, as minitest is no longer part of stdlib.

Also, stub env variables instead of changing ENV hash. This now uses ClimateControl to stub the environment instead of directly
modifying the ENV hash. This allows the tests to be run in a random order.