### PR TITLE
Add documentation on Plek environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ See the [API docs](http://www.rubydoc.info/gems/plek) for full details of the AP
 
 ### Environment variables
 
+#### For base URLs
+
 The base URL Plek uses for each service can be set using environment variables.
 
 Plek will use any variables set matching this pattern:
@@ -29,6 +31,16 @@ Plek will use any variables set matching this pattern:
 `PLEK_SERVICE_` + the service name, uppercased with any hyphens converted to underscores + `_URI`.
 
 For example, the variable for `static` would be `PLEK_SERVICE_STATIC_URI`.
+
+#### Others
+
+To override the development environment base domain, set `DEV_DOMAIN`. The default is `dev.gov.uk`. The environment can be set using either `RAILS_ENV` or `RACK_ENV`.
+
+You can prepend strings to the hostnames generated using: `PLEK_HOSTNAME_PREFIX`.
+
+Override the asset URL with: `GOVUK_ASSET_ROOT`. The default is to generate a URL for the `static` service.
+
+Override the website root with `GOVUK_WEBSITE_ROOT`. The default is to generate a URL for the `www` service.
 
 ## Licence
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ See the [API docs](http://www.rubydoc.info/gems/plek) for full details of the AP
 
 `bundle exec rake`
 
+### Environment variables
+
+The base URL Plek uses for each service can be set using environment variables.
+
+Plek will use any variables set matching this pattern:
+
+`PLEK_SERVICE_` + the service name, uppercased with any hyphens converted to underscores + `_URI`.
+
+For example, the variable for `static` would be `PLEK_SERVICE_STATIC_URI`.
+
 ## Licence
 
 [MIT License](LICENCE)


### PR DESCRIPTION
Documentation on the environment variables from apps that use Plek (such as [this](https://github.com/alphagov/static#running-locally) from static) don't explain what they do and you currently have to find the [code that uses them](https://github.com/alphagov/plek/blob/master/lib/plek.rb#L159) to understand this.

This adds some explanation to the README.