### PR TITLE
Add public_asset_host method

### DIFF
--- a/lib/plek.rb
+++ b/lib/plek.rb
@@ -92,6 +92,13 @@ class Plek
     env_var_or_dev_fallback("GOVUK_ASSET_ROOT") { find("static") }
   end
 
+  # Find the asset host used to serve assets to the public
+  #
+  # @return [String] The public-facing asset base URL
+  def public_asset_host
+    env_var_or_dev_fallback("GOVUK_ASSET_HOST") { find("static") }
+  end
+
   # Find the base URL for the public website frontend.
   #
   # @return [String] The website base URL.

--- a/test/asset_root_test.rb
+++ b/test/asset_root_test.rb
@@ -1,7 +1,7 @@
 require_relative "test_helper"
 
 describe Plek do
-  describe "retreiving the asset_host" do
+  describe "retreiving the asset_root" do
     it "should return the GOVUK_ASSET_ROOT env variable" do
       ClimateControl.modify GOVUK_ASSET_ROOT: "http://static.dev.gov.uk" do
         assert_equal "http://static.dev.gov.uk", Plek.new("foo.gov.uk").asset_root

--- a/test/asset_root_test.rb
+++ b/test/asset_root_test.rb
@@ -1,15 +1,15 @@
 require_relative "test_helper"
 
 describe Plek do
-  describe "retreiving the asset_root" do
-    it "should return the GOVUK_ASSET_ROOT env variable" do
+  describe "asset_root" do
+    it "returns the GOVUK_ASSET_ROOT env variable" do
       ClimateControl.modify GOVUK_ASSET_ROOT: "http://static.dev.gov.uk" do
         assert_equal "http://static.dev.gov.uk", Plek.new("foo.gov.uk").asset_root
       end
     end
 
     describe "When GOVUK_ASSET_ROOT env variable isn't set" do
-      it "should raise an exception if RAILS_ENV is production" do
+      it "raises an exception if RAILS_ENV is production" do
         ClimateControl.modify RAILS_ENV: "production" do
           assert_raises Plek::NoConfigurationError do
             Plek.new("foo.gov.uk").asset_root
@@ -17,7 +17,7 @@ describe Plek do
         end
       end
 
-      it "should raise an exception if RACK_ENV is production" do
+      it "raises an exception if RACK_ENV is production" do
         ClimateControl.modify RACK_ENV: "production" do
           assert_raises Plek::NoConfigurationError do
             Plek.new("foo.gov.uk").asset_root
@@ -25,7 +25,7 @@ describe Plek do
         end
       end
 
-      it "should return find('static') otherwise" do
+      it "returns find('static') otherwise" do
         assert_equal "https://static.foo.gov.uk", Plek.new("foo.gov.uk").asset_root
       end
     end

--- a/test/public_asset_host_test.rb
+++ b/test/public_asset_host_test.rb
@@ -1,0 +1,33 @@
+require_relative "test_helper"
+
+describe Plek do
+  describe "public_asset_host" do
+    it "returns the GOVUK_ASSET_HOST env variable" do
+      ClimateControl.modify GOVUK_ASSET_HOST: "https://assets.digital.cabinet-office.gov.uk" do
+        assert_equal "https://assets.digital.cabinet-office.gov.uk", Plek.new("foo.gov.uk").public_asset_host
+      end
+    end
+
+    describe "When GOVUK_ASSET_HOST env variable isn't set" do
+      it "raises an exception if RAILS_ENV is production" do
+        ClimateControl.modify RAILS_ENV: "production" do
+          assert_raises Plek::NoConfigurationError do
+            Plek.new("foo.gov.uk").public_asset_host
+          end
+        end
+      end
+
+      it "raises an exception if RACK_ENV is production" do
+        ClimateControl.modify RACK_ENV: "production" do
+          assert_raises Plek::NoConfigurationError do
+            Plek.new("foo.gov.uk").public_asset_host
+          end
+        end
+      end
+
+      it "returns find('static') otherwise" do
+        assert_equal "https://static.foo.gov.uk", Plek.new("foo.gov.uk").public_asset_host
+      end
+    end
+  end
+end


### PR DESCRIPTION
This returns the `GOVUK_ASSET_HOST`, which is suitable for public
consumption. This will resolve to
https://assets.digital.cabinet-office.gov.uk in production.

This is mostly needed for Publishing apps like Whitehall to
differentiate between the Rails-style asset root used to serve JS and
CSS for Admin interfaces, versus the public CDN that they should
reference in content that is pushed to publishing-api.