### PR TITLE
Use "publishing.service.gov.uk" as the example production hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Plek.find('frontend')
 ```
 
 returns `http://frontend.dev.gov.uk` on a development machine and
-`https://frontend.production.alphagov.co.uk` on a production machine. This
+`https://frontend.publishing.service.gov.uk` on a production machine. This
 means we can use this in our code and let our environment configuration figure
 out the correct hosts for us at runtime.
 


### PR DESCRIPTION
- I was just explaining Plek to someone and referred to the README,
  only to notice that it still referenced "production.alphagov.co.uk" rather
  than "publishing.service.gov.uk" for production hosts. Testing this on
  Integration, "Plek.new.find('frontend')" returns
  "https://frontend.integration.publishing.service.gov.uk", so I assume it works the
  same way in production.