### PR TITLE
Update test to use ClimateControl

### DIFF
--- a/test/service_uri_test.rb
+++ b/test/service_uri_test.rb
@@ -35,8 +35,9 @@ describe Plek do
     end
 
     it "ignores the force_http parameter" do
-      ENV["PLEK_SERVICE_FOO_URI"] = "https://foo.localhost:5001"
-      assert_equal "https://foo.localhost:5001", Plek.new().find("foo", :force_http => true)
+      ClimateControl.modify PLEK_SERVICE_FOO_URI: "https://foo.localhost:5001" do
+        assert_equal "https://foo.localhost:5001", Plek.new().find("foo", :force_http => true)
+      end
     end
   end
 end


### PR DESCRIPTION
We started using ClimateControl to set environment variables in
ae30a91aa, but this test was written before that change. This change
also appears to fix a broken build under Ruby 2.2.4:

    1) Failure:
    PlekTest#test_should_prepend_data_from_the_environment [/home/jenkins/workspace/govuk_plek/test/plek_test.rb:96]:
    --- expected
    +++ actual
    @@ -1 +1 @@
    -"https://test-foo.preview.alphagov.co.uk"
    +"https://foo.localhost:5001"

https://ci.dev.publishing.service.gov.uk/job/govuk_plek/89/console