### PR TITLE
Production-like affordance methods

### DIFF
--- a/lib/plek.rb
+++ b/lib/plek.rb
@@ -1,4 +1,5 @@
 require 'plek/version'
+require 'plek/production_like'
 require 'uri'
 
 # Plek resolves service names to a corresponding base URL.
@@ -13,6 +14,8 @@ require 'uri'
 # environment variables being set to "development"), Plek provides some default
 # values when the necessary environment variables aren't set detailed below.
 class Plek
+  include Plek::ProductionLike
+
   # Raised when a required environment variable is not set.
   class NoConfigurationError < StandardError; end
 

--- a/lib/plek/production_like.rb
+++ b/lib/plek/production_like.rb
@@ -1,0 +1,30 @@
+class Plek
+  ##
+  # Affordance methods for telling what type of environment we're in.
+  # Allows us to do things like test pre-production code in integration
+  # or tell what kind of environment we're in when we're not in a Rails app
+  module ProductionLike
+    def environment
+      @environment ||= begin
+        match = parent_domain.match('^(?<env_name>.+?)\.')
+
+        case match[:env_name]
+        when 'dev', nil
+          :development
+        else
+          match[:env_name].to_sym
+        end
+      end
+    end
+
+    def production_like?
+      [:integration, :staging, :production].include?(environment)
+    end
+
+    %w(development integration staging production).each do |env|
+      define_method "#{env}?".to_sym do
+        self.environment == env.to_sym
+      end
+    end
+  end
+end

--- a/test/production_like_test.rb
+++ b/test/production_like_test.rb
@@ -1,0 +1,56 @@
+require_relative "test_helper"
+
+class ProductionLikeTest < Minitest::Test
+  def test_environment
+    {
+      'integration.publishing.service.gov.uk' => :integration,
+                                 'dev.gov.uk' => :development,
+          'staging.publishing.service.gov.uk' => :staging
+    }.each do |domain, expected_environment|
+      plek = Plek.new(domain)
+      assert_equal expected_environment, plek.environment
+    end
+  end
+
+  def test_development?
+    plek = Plek.new('dev.gov.uk')
+    assert_equal true, plek.development?
+    plek = Plek.new('integration.gov.uk')
+    assert_equal false, plek.development?
+  end
+
+  def test_integration?
+    plek = Plek.new('integration.gov.uk')
+    assert_equal true, plek.integration?
+    plek = Plek.new('staging.gov.uk')
+    assert_equal false, plek.integration?
+  end
+
+  def test_staging?
+    plek = Plek.new('staging.gov.uk')
+    assert_equal true, plek.staging?
+    plek = Plek.new('integration.gov.uk')
+    assert_equal false, plek.staging?
+  end
+
+  def test_production?
+    plek = Plek.new('production.gov.uk')
+    assert_equal true, plek.production?
+    plek = Plek.new('staging.gov.uk')
+    assert_equal false, plek.production?
+  end
+
+  def test_production_like_environments
+    %w(integration.gov.uk staging.gov.uk production.gov.uk).each do |domain|
+      production_like = Plek.new(domain).production_like?
+      assert_equal true, production_like, "#{domain} should be production_like?"
+    end
+  end
+
+  def test_not_production_like_environments
+    %w(test.gov.uk dev.gov.uk).each do |domain|
+      production_like = Plek.new(domain).production_like?
+      assert_equal false, production_like, "#{domain} should not be production_like?"
+    end
+  end
+end


### PR DESCRIPTION
We had a situation on Specialist Publisher where we needed to know what environment we were in exactly. Things needed to be visible on dev and integration (a dev-facing environment) that needed to be invisible on the more public-facing environments (staging and production).

This PR adds some affordances to Plek instances around current GOV.UK environments via a module. I have no idea if it's hopelessly naïve, so this is a request for comments.