### PR TITLE
Freeze the strings returned from Plek.find

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+# Unreleased
+
+  * Consistently return a frozen string from the `Plek.find` method.
+
 # 1.12.0
 
   * Add `Plek.public_asset_host` for accessing `GOVUK_ASSET_HOST` environment variable

--- a/lib/plek.rb
+++ b/lib/plek.rb
@@ -68,11 +68,11 @@ class Plek
     end
 
     if options[:scheme_relative]
-      "//#{host}"
+      "//#{host}".freeze
     elsif options[:force_http] or HTTP_DOMAINS.include?(parent_domain)
-      "http://#{host}"
+      "http://#{host}".freeze
     else
-      "https://#{host}"
+      "https://#{host}".freeze
     end
   end
 


### PR DESCRIPTION
For ruby 2.3 or greater, if there is an explicit URI set for the
service in the environment, the return value is already frozen. For
consistency, always return a frozen string.