### PR TITLE
[WIP] Allow use of GOVUK_APP_DOMAIN_INTERNAL

### DIFF
--- a/lib/plek.rb
+++ b/lib/plek.rb
@@ -61,7 +61,13 @@ class Plek
       return service_uri
     end
 
-    host = "#{name}.#{parent_domain}"
+    if options[:internal]
+      domain_suffix = ENV['GOVUK_APP_DOMAIN_INTERNAL'] || parent_domain
+    else
+      domain_suffix = parent_domain
+    end
+
+    host = "#{name}.#{domain_suffix}"
 
     if host_prefix = ENV['PLEK_HOSTNAME_PREFIX']
       host = "#{host_prefix}#{host}"

--- a/test/plek_test.rb
+++ b/test/plek_test.rb
@@ -102,4 +102,15 @@ class PlekTest < Minitest::Test
     assert_equal "//service.dev.gov.uk", url
   end
 
+  def test_should_return_internal_when_env_var_set_and_internal_parameter_passed
+    ClimateControl.modify GOVUK_APP_DOMAIN_INTERNAL: 'internal.domain' do
+      assert_equal "http://foo.internal.domain", Plek.find("foo", internal: true)
+    end
+  end
+
+  def test_should_not_return_internal_when_env_var_not_set_but_internal_parameter_passed
+    ClimateControl.modify GOVUK_APP_DOMAIN_INTERNAL: nil do
+      assert_equal Plek.find("foo", internal: true), Plek.find("foo")
+    end
+  end
 end


### PR DESCRIPTION
In AWS, we use both internal and "public" DNS names in how we route traffic. Traffic between services within the environment should always be internal.

Applications use Plek for service discovery of internal services, but also use it for self referred lookups for user facing redirects. This causes an issue as we cannot set the default service discovery to use the internal domains incase we send a user to the wrong URL.

In most places we set PLEK_SERVICE_APPLICATION_URI to ensure overrides happen in the correct places.

However, content-store [uses a Plek lookup to help set a backend route][1], and we cannot determine which specific service it will do this for. I am hesitant to set the default GOVUK_APP_DOMAIN as the internal domain as I do not know what side effects this may cause, but we do know that Router backends should almost always refer to the internal domain to route traffic.

We previously [set GOVUK_APP_DOMAIN_INTERNAL environment variable][2] to use within Smokey, so we can make use of the this.

We can specifically ask Plek to use the internal domain, and only set it if the appropriate environment variable exists.

[1]: https://github.com/alphagov/content-store/blob/3ea284672bc2ee15a6f17c9936847cbc7f605ea0/app/models/route_set.rb#L102
[2]: https://github.com/alphagov/govuk-puppet/commit/d7d231efde8b498c07c727ab448c20c507396749

Paired with @timmow on his last day.