### PR TITLE
Fallback to GOVUK_APP_DOMAIN when GOVUK_APP_DOMAIN_EXTERNAL isn't set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+# Unreleased
+
+  * Fallback to `GOVUK_APP_DOMAIN` when `GOVUK_APP_DOMAIN_EXTERNAL` is not set
+
 # 2.1.0
 
   * Add support for external domains, and the

--- a/README.md
+++ b/README.md
@@ -3,14 +3,28 @@
 "Plek" is Afrikaans. It means "Location". Plek is used to generate the correct
 base URLs for internal GOV.UK services, eg:
 
-```ruby
-Plek.find('frontend')
+```
+# on a dev machine
+> Plek.find('frontend')
+=> "http://frontend.dev.gov.uk"
+# on a production machine
+> Plek.find('frontend')
+=> "https://frontend.publishing.service.gov.uk"
 ```
 
-returns `http://frontend.dev.gov.uk` on a development machine and
-`https://frontend.publishing.service.gov.uk` on a production machine. This
-means we can use this in our code and let our environment configuration figure
-out the correct hosts for us at runtime.
+This means we can use this in our code and let our environment configuration
+figure out the correct hosts for us at runtime.
+
+In an environment where we have internal hostnames and external ones an option
+of `external` can be provided to determine whether an internal or external
+host is returned.
+
+```
+> Plek.find('frontend')
+=> "https://frontend.integration.govuk-internal.digital"
+> Plek.find('frontend', external: true)
+=> "https://frontend.integration.publishing.service.gov.uk"
+```
 
 ## Technical documentation
 

--- a/lib/plek.rb
+++ b/lib/plek.rb
@@ -33,8 +33,7 @@ class Plek
   #   variable is unset.
   def initialize(domain_to_use = nil, external_domain = nil)
     self.parent_domain = domain_to_use || env_var_or_dev_fallback("GOVUK_APP_DOMAIN", DEV_DOMAIN)
-    self.external_domain = external_domain ||
-                           env_var_or_dev_fallback("GOVUK_APP_DOMAIN_EXTERNAL", DEV_DOMAIN)
+    self.external_domain = external_domain || ENV["GOVUK_APP_DOMAIN_EXTERNAL"] || parent_domain
   end
 
   # Find the base URL for a service/application. This constructs the URL from

--- a/lib/plek.rb
+++ b/lib/plek.rb
@@ -26,11 +26,16 @@ class Plek
 
   # Construct a new Plek instance.
   #
-  # @param domain_to_use [String] Optionally override the parent domain to use.
-  #   If unspecified, this uses the +GOVUK_APP_DOMAIN+ environment variable.
+  # @param domain_to_use [String, nil] Optionally override the parent domain
+  #   to use. If unspecified, this uses the +GOVUK_APP_DOMAIN+ environment
+  #   variable.
   #
   #   In development mode, this falls back to {DEV_DOMAIN} if the environment
   #   variable is unset.
+  # @param external_domain [String, nil] Optionally override the external
+  #   domain to use. If unspecified it will fall back to using
+  #   +GOVUK_APP_DOMAIN_EXTERNAL+ and if that is unavailable the parent domain
+  #   will be used
   def initialize(domain_to_use = nil, external_domain = nil)
     self.parent_domain = domain_to_use || env_var_or_dev_fallback("GOVUK_APP_DOMAIN", DEV_DOMAIN)
     self.external_domain = external_domain || ENV["GOVUK_APP_DOMAIN_EXTERNAL"] || parent_domain


### PR DESCRIPTION
Introducing the need for this environment variable (in https://github.com/alphagov/plek/pull/55) seems to have
caused a variety of pain points with situations where we don't have a
GOVUK_APP_DOMAIN_EXTERNAL set. Frequently we're seeing builds fail due
to the missing env var. In most cases where it doesn't exist
GOVUK_APP_DOMAIN is set to an external domain anyway.

This sets the env var to fallback to the parent domain if that is set
which should make this change now backwards compatible.