### PR TITLE
Set specific version of rubocop-govuk

### DIFF
--- a/plek.gemspec
+++ b/plek.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "climate_control"
   s.add_development_dependency "minitest"
   s.add_development_dependency "rake"
-  s.add_development_dependency "rubocop-govuk"
+  s.add_development_dependency "rubocop-govuk", "4.7.0"
 end


### PR DESCRIPTION
This prevents developers using different versions of rubocop depending on when they cloned the repo (as there is no Gemfile.lock committed).