### PR TITLE
Add features needed by Replatforming.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # CHANGELOG
 
+# Unreleased
+
+  * Allow setting `GOVUK_APP_DOMAIN=""` (empty string). Similarly for
+    `GOVUK_APP_DOMAIN_EXTERNAL`. This allows single-label domains to be used in
+    service URLs instead of FQDNs, which eliminates a lot of configuration
+    complexity when running on Kubernetes. This also paves the way for
+    eventually retiring Plek, if we want.
+  * Take an optional, comma-separated list of hostnames
+    `PLEK_UNPREFIXABLE_HOSTS` not to be prefixed even when
+    `PLEK_HOSTNAME_PREFIX` is set. This simplifies the configuration of the
+    draft stack in Kubernetes.
+  * Support using `http` as the URL scheme for single-label domains when
+    `PLEK_USE_HTTP_FOR_SINGLE_LABEL_DOMAINS=1`. (A single-label domain looks
+    like `content-store`, as opposed to `content-store.test.govuk.digital`.)
+    This is is needed in order to run in Kubernetes without a service mesh,
+    without hard-to-maintain configuration logic to generate domains names
+    depending on the environment.
+
 # 4.0.0
 
   * Remove #public_asset_host method since it is no longer used by any GOV.UK apps.

--- a/README.md
+++ b/README.md
@@ -52,9 +52,19 @@ To domain is based on the environment, and defaults to 'dev.gov.uk'. The environ
 
 You can prepend strings to the hostnames generated using: `PLEK_HOSTNAME_PREFIX`.
 
+If `PLEK_HOSTNAME_PREFIX` is present, it will be prepended to the hostname
+unless the hostname appears in the comma-separated list
+`PLEK_UNPREFIXABLE_HOSTS`.
+
 Override the asset URL with: `GOVUK_ASSET_ROOT`. The default is to generate a URL for the `static` service.
 
 Override the website root with `GOVUK_WEBSITE_ROOT`. The default is to generate a URL for the `www` service.
+
+If `PLEK_USE_HTTP_FOR_SINGLE_LABEL_DOMAINS=1` (or anything beginning with `t`
+or `y`), Plek will use `http` as the URL scheme instead of `https` for
+single-label domains. Single-label domains are domains with just a single name
+component, for example `frontend` or `content-store`, as opposed to
+`frontend.example.com` or `content-store.test.govuk.digital`.
 
 ## Licence
 


### PR DESCRIPTION
We need some more flexibility in how Plek constructs URLs for services, in order to keep the complexity of govuk-helm-charts within reasonable bounds and keep everything maintainable.

- Support empty domain suffixes. This simplifies GOV.UK's Helm charts by eliminating the need to construct domain names containing the environment name. We can simply use the cluster DNS like we're supposed to, so the hostname for Content Store is just `content-store` and the local resolver expands that to `content-store.apps.svc.cluster.local`. This makes it somewhat easier to retire Plek in the long run.
- Support a list of hostnames to exclude from `PLEK_HOSTNAME_PREFIX`. This simplifies the configuration of the draft stack by saving us from having to specify a bunch of overrides for every draft app.
- Support constructing `http://` URLs for within-cluster services. (This traffic stays within the VPC, so it's encrypted before it hits the optical network anyway. The old GOV.UK doesn't actually use TLS between the load balancer and the EC2 VMs, so this is equivalent to what we already have.)

Also refactor `find()` to make the logic easier to follow.

This change is intended to be backward compatible with all current usage in govuk-puppet and client apps. In other words it's only supposed to affect Replatforming and not the existing setup.

Tested: added tests to cover the new functionality.

#### Alternatives considered

Previously our intent was to configure every backend address explicitly for every client app, with a view to eventually retiring Plek. Unfortunately that turned out to be much less feasible that any of us had anticipated, particularly when we consider how to configure the draft stack while keeping the Helm charts maintainable (avoiding excessive or risky duplication without having a silly number of levels of templating) and guarding against the most undesirable failure modes in the event of configuration errors (like ensuring it's still really hard to accidentally have draft content go live before it's supposed to).

Some more of the background to this is outlined in https://github.com/alphagov/govuk-helm-charts/commit/b7e360b. The preferred approach proposed in this PR will avoid a lot of that sort of complexity.