### PR TITLE
Release version 4.1.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # Unreleased
 
+  * Deprecate usage of `Plek.current` this method will be removed in next
+    major version. This adds a warning for users.
   * Allow setting `GOVUK_APP_DOMAIN=""` (empty string). Similarly for
     `GOVUK_APP_DOMAIN_EXTERNAL`. This allows single-label domains to be used in
     service URLs instead of FQDNs, which eliminates a lot of configuration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,14 @@
 
 # Unreleased
 
+Nothing yet.
+
+# 4.1.0
+
   * Deprecate usage of `Plek.current` this method will be removed in next
     major version. This adds a warning for users.
+  * Remove public setter methods for `parent_domain` and `external_domain`.
+    These are not used anywhere so there are no API compatibility issues.
   * Allow setting `GOVUK_APP_DOMAIN=""` (empty string). Similarly for
     `GOVUK_APP_DOMAIN_EXTERNAL`. This allows single-label domains to be used in
     service URLs instead of FQDNs, which eliminates a lot of configuration

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 # Specify your gem's dependencies in plek.gemspec
 gemspec

--- a/README.md
+++ b/README.md
@@ -72,4 +72,4 @@ component, for example `frontend` or `content-store`, as opposed to
 
 ## Versioning policy
 
-This is versioned according to [Semantic Versioning 2.0](http://semver.org/)
+This is versioned according to [Semantic Versioning 2.0](https://semver.org/)

--- a/lib/plek.rb
+++ b/lib/plek.rb
@@ -144,7 +144,10 @@ class Plek
     #     Plek.current.find('foo')
     # as well as the new style:
     #     Plek.new.find('foo')
-    alias_method :current, :new
+    def current(...)
+      warn "Plek.current is deprecated and will be removed. Use Plek.new or Plek.find instead."
+      new(...)
+    end
 
     # Convenience wrapper.  The same as calling +Plek.new.find+.
     # @see #find

--- a/lib/plek/version.rb
+++ b/lib/plek/version.rb
@@ -1,3 +1,3 @@
 class Plek
-  VERSION = "4.0.0".freeze
+  VERSION = "4.1.0".freeze
 end

--- a/test/plek_test.rb
+++ b/test/plek_test.rb
@@ -75,7 +75,11 @@ class PlekTest < Minitest::Test
 
   def test_should_be_able_to_use_current_for_old_style_calls
     ClimateControl.modify GOVUK_APP_DOMAIN: "foo.bar.baz" do
-      assert_equal Plek.new.find("foo"), Plek.current.find("foo")
+      old_style = nil
+      assert_output("", "Plek.current is deprecated and will be removed. Use Plek.new or Plek.find instead.\n") do
+        old_style = Plek.current.find("foo")
+      end
+      assert_equal Plek.new.find("foo"), old_style
     end
   end
 


### PR DESCRIPTION
If we wanted to be super strict, we could view removing the unused setter methods for `parent_domain` and `external_domain` as a compatibility-breaking API change. There isn't a single usage of these anywhere though, so in practice it's more helpful to consider this a minor release as it's supposed to be 100% compatible with all existing usage.

Also, start using `https` when fetching gem dependencies during build.