### PR TITLE
Deprecate the use of Plek.current

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Nothing yet.
 
 # 4.1.0
 
+  * Deprecate usage of `Plek.current` this method will be removed in next
+    major version. This adds a warning for users.
   * Remove public setter methods for `parent_domain` and `external_domain`.
     These are not used anywhere so there are no API compatibility issues.
   * Allow setting `GOVUK_APP_DOMAIN=""` (empty string). Similarly for

--- a/lib/plek.rb
+++ b/lib/plek.rb
@@ -144,7 +144,10 @@ class Plek
     #     Plek.current.find('foo')
     # as well as the new style:
     #     Plek.new.find('foo')
-    alias_method :current, :new
+    def current(...)
+      warn "Plek.current is deprecated and will be removed. Use Plek.new or Plek.find instead."
+      new(...)
+    end
 
     # Convenience wrapper.  The same as calling +Plek.new.find+.
     # @see #find

--- a/test/plek_test.rb
+++ b/test/plek_test.rb
@@ -75,7 +75,11 @@ class PlekTest < Minitest::Test
 
   def test_should_be_able_to_use_current_for_old_style_calls
     ClimateControl.modify GOVUK_APP_DOMAIN: "foo.bar.baz" do
-      assert_equal Plek.new.find("foo"), Plek.current.find("foo")
+      old_style = nil
+      assert_output("", "Plek.current is deprecated and will be removed. Use Plek.new or Plek.find instead.\n") do
+        old_style = Plek.current.find("foo")
+      end
+      assert_equal Plek.new.find("foo"), old_style
     end
   end
 


### PR DESCRIPTION
This method was put in temporarily 10 years ago [1] and has had a todo next to it ever since. We're planning to finally remove this [2] in the 5.0 release so this acts as a warning in the interim.

[1]: https://github.com/alphagov/plek/commit/309ef5942a7adcdc6d68a9416fa3267c17a2268f
[2]: https://github.com/alphagov/plek/pull/93