### PR TITLE
Remove extra dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,6 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-    time: "03:00"
-  open-pull-requests-limit: 10
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:


### PR DESCRIPTION
Trello: https://trello.com/c/QrxjshEm/270-move-ruby-gems-from-jenkins-to-github-actions

We don't typically have this in our gems so removing this for consistency.