### PR TITLE
Introduce 10 day cooldown period for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,16 @@
+---
 version: 2
 updates:
 - package-ecosystem: bundler
-  directory: "/"
+  directory: /
   schedule:
     interval: daily
-- package-ecosystem: "github-actions"
-  directory: "/"
+  cooldown:
+    default-days: 10
+- package-ecosystem: github-actions
+  directory: /
   schedule:
     interval: daily
+  cooldown:
+    default-days: 10
+...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+# 5.3.1
+* Set dependency cooldowns for Dependabot
+
 # 5.3.0
 
 * Drop support for Ruby 3.1

--- a/lib/plek/version.rb
+++ b/lib/plek/version.rb
@@ -1,3 +1,3 @@
 class Plek
-  VERSION = "5.3.0".freeze
+  VERSION = "5.3.1".freeze
 end


### PR DESCRIPTION
## What

Adds 10 day dependency cooldowns for Dependabot and Renovate as appropriate
