### PR TITLE
BAU - Name GitHub actions so automerger can work

### DIFF
--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -1,3 +1,5 @@
+name: Auto-release Rubygem
+
 on:
   workflow_dispatch: {}
   schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+name: CI
+
 on: [push, pull_request]
 
 concurrency:

--- a/.github/workflows/gem-bump-checker.yml
+++ b/.github/workflows/gem-bump-checker.yml
@@ -1,3 +1,5 @@
+name: Gem Bump Checker
+
 on:
   workflow_dispatch: {}
   pull_request: {}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+# 5.3.2
+* Name GitHub Actions for [govuk-dependabot-merger](https://github.com/alphagov/govuk-dependabot-merger) to automerge
+
 # 5.3.1
 * Set dependency cooldowns for Dependabot
 

--- a/lib/plek/version.rb
+++ b/lib/plek/version.rb
@@ -1,3 +1,3 @@
 class Plek
-  VERSION = "5.3.1".freeze
+  VERSION = "5.3.2".freeze
 end


### PR DESCRIPTION
Description:
- GitHub Actions need to be named so https://github.com/alphagov/govuk-dependabot-merger can automerge dependencies

